### PR TITLE
Use icinga2 user/group for logrotate file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vir.khatri@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Icinga2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.7.1'
+version '2.7.2'
 
 depends 'apt'
 depends 'yum', '~> 3.0'

--- a/recipes/core_config.rb
+++ b/recipes/core_config.rb
@@ -61,7 +61,10 @@ template '/etc/logrotate.d/icinga2' do
   owner 'root'
   group 'root'
   mode 0644
-  variables(:log_dir => node['icinga2']['log_dir'])
+  variables(:log_dir => node['icinga2']['log_dir'],
+            :user    => node['icinga2']['user'],
+            :group   => node['icinga2']['group'],
+           )
 end
 
 # icinga2.conf

--- a/templates/default/icinga2.logrotate.erb
+++ b/templates/default/icinga2.logrotate.erb
@@ -5,30 +5,30 @@
 
 <%= @log_dir -%>/icinga2.log <%= @log_dir -%>/debug.log {
   daily
-	rotate 7
-	su icinga icinga
-	compress
-	delaycompress
+        rotate 7
+        su <%= @user %> <%= @group %>
+        compress
+        delaycompress
   missingok
   notifempty
-  create 644 icinga icinga
-	copytruncate
-	postrotate
-		if ! killall -q -USR1 icinga2; then
-			exit 1
-		fi
+  create 644 <%= @user %> <%= @group %>
+        copytruncate
+        postrotate
+              if ! killall -q -USR1 icinga2; then
+                exit 1
+              fi
   endscript
 }
 
 <%= @log_dir -%>/error.log {
 	daily
-	su icinga icinga
+  su <%= @user %> <%= @group %>
 	rotate 90
 	compress
 	delaycompress
 	missingok
 	notifempty
-	create 644 icinga icinga
+        create 644 <%= @user %> <% @group %>
 	copytruncate
 	# TODO: figure out how to get Icinga to re-open this log file
 }


### PR DESCRIPTION
The cookbook creates a 'nagios' user/group on debian platforms, but the
logrotate template had hardcoded an 'icinga' user/group. On debian
platforms, that means the logrotate job fails. The fix here is to use
the attributes that define the user/group created by the cookbook.
